### PR TITLE
added `room` to `onConnected` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export const RoomPage = () => {
   )
 }
 
-function onConnected() {
+function onConnected(room) {
   const audioTrack = await createLocalAudioTrack()
   await room.localParticipant.publishTrack(audioTrack)
   const videoTrack = await createLocalVideoTrack();


### PR DESCRIPTION
**Changes**
- added room parameter to onConnected function in the readme


**Reason**
- Copy pasting the boilerplate from the readme threw an error, room does not exist. Adding room as a parameter for onConnected rectified this.