### PR TITLE
Add option to example room page to support recorder

### DIFF
--- a/example/src/RoomPage.tsx
+++ b/example/src/RoomPage.tsx
@@ -12,6 +12,7 @@ export const RoomPage = () => {
   const query = new URLSearchParams(useLocation().search)
   const url = query.get('url')
   const token = query.get('token')
+  const recorder = query.get('recorder')
 
   if (!url || !token) {
     return (
@@ -31,6 +32,15 @@ export const RoomPage = () => {
     setNumParticipants(room.participants.size + 1);
   }
 
+  const onParticipantDisconnected = (room: Room) => {
+    updateParticipantSize(room)
+    
+    /* Special rule for recorder */
+    if (recorder && parseInt(recorder, 10) === 1 && room.participants.size === 0) {
+      console.log("END_RECORDING")
+    }
+  }
+
   return (
     <div className="roomContainer">
       <div className="topBar">
@@ -46,7 +56,7 @@ export const RoomPage = () => {
         onConnected={room => {
           onConnected(room, query);
           room.on(RoomEvent.ParticipantConnected, () => updateParticipantSize(room))
-          room.on(RoomEvent.ParticipantDisconnected, () => updateParticipantSize(room))
+          room.on(RoomEvent.ParticipantDisconnected, () => onParticipantDisconnected(room))
           updateParticipantSize(room);
         }}
         onLeave={onLeave}


### PR DESCRIPTION
Changes here are requested to support development of recording. If a parameter is passed via url `recorder=1`, then the room page will log 'END_RECORDING' to the console when the last participant (excluding the local participant) disconnects from the room.