### PR TITLE
Use namespace expose for react-aspect-ratio

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "livekit-react": "link:..",
     "livekit-client": "link:../node_modules/livekit-client",
     "react": "link:../node_modules/react",
-    "react-aspect-ratio": "^1.0.49",
+    "react-aspect-ratio": "^1.0.50",
     "react-dom": "link:../node_modules/react-dom",
     "react-router-dom": "^5.2.0",
     "react-scripts": "link:../node_modules/react-scripts",

--- a/example/src/PreJoinPage.tsx
+++ b/example/src/PreJoinPage.tsx
@@ -2,7 +2,7 @@ import { faBolt } from '@fortawesome/free-solid-svg-icons'
 import { createLocalVideoTrack, CreateVideoTrackOptions, LocalVideoTrack } from 'livekit-client'
 import { AudioSelectButton, ControlButton, VideoRenderer, VideoSelectButton } from 'livekit-react'
 import React, { ReactElement, useEffect, useRef, useState } from "react"
-import AspectRatio from 'react-aspect-ratio'
+import { AspectRatio } from 'react-aspect-ratio'
 import { useHistory } from 'react-router-dom'
 
 export const PreJoinPage = () => {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -6788,10 +6788,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-livekit-client@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-0.8.4.tgz#4edd29403f17713293739ccaa84c68d64360bd78"
-  integrity sha512-UxBDOLHciam5i6CivQAC1mZODiIniiYiclTWpJsYbq7MccShZGBArbrn5QP0HDRTQ9oWtUGcEMrPAT+EMsrA2w==
+livekit-client@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-0.11.2.tgz#899f4ae5ceb7ba3df03b21c5e02456edd978ec53"
+  integrity sha512-RYNKw9dNAcrCviLbdn7FhjmmfO0KQ6nc2JPE11nimKkVCo/taZCFsZLiMq5QlLNRYaNzQ1ul+03bY2SevOvIUA==
   dependencies:
     "@types/ws" "^7.4.0"
     events "^3.3.0"
@@ -8992,10 +8992,10 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
-react-aspect-ratio@^1.0.49:
-  version "1.0.49"
-  resolved "https://registry.yarnpkg.com/react-aspect-ratio/-/react-aspect-ratio-1.0.49.tgz#346863ebb7eec542b8a5a4d6548440bf95a88608"
-  integrity sha512-zSKVJdy7QjmFeWTNNoL+gLf4KugIVln6XdKNIxjY8yebJ0buCeKcKoEQPfxruSbPGFakFGVl/abtF9SDpauh/A==
+react-aspect-ratio@^1.0.50:
+  version "1.0.50"
+  resolved "https://registry.yarnpkg.com/react-aspect-ratio/-/react-aspect-ratio-1.0.50.tgz#b46bfc6a701d829bd0cb6d001cf271e443874213"
+  integrity sha512-AEAPqmPMLlcuhp4t3z6crb+gGckc0lFPYNL/654a6rrcblcvZGtgh+VpcUbC7AwIE+MT8u5uGeJ7shx0hUOKSw==
 
 react-dev-utils@^10.2.1:
   version "10.2.1"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@types/react-responsive": "^8.0.2",
     "livekit-client": "^0.11.2",
-    "react-aspect-ratio": "^1.0.49",
+    "react-aspect-ratio": "^1.0.50",
     "react-intersection-observer": "^8.32.0",
     "react-responsive": "^8.2.0",
     "react-tiny-popover": "^6.0.5"

--- a/src/components/ParticipantView.tsx
+++ b/src/components/ParticipantView.tsx
@@ -12,7 +12,7 @@ import {
 } from "livekit-client";
 import { VideoQuality } from "livekit-client/dist/proto/livekit_rtc";
 import React, { CSSProperties, ReactElement, useEffect, useState } from "react";
-import AspectRatio from "react-aspect-ratio";
+import { AspectRatio } from "react-aspect-ratio";
 import { useInView } from "react-intersection-observer";
 import { useParticipant } from "../useParticipant";
 import styles from "./styles.module.css";

--- a/yarn.lock
+++ b/yarn.lock
@@ -9781,10 +9781,10 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
-react-aspect-ratio@^1.0.49:
-  version "1.0.49"
-  resolved "https://registry.yarnpkg.com/react-aspect-ratio/-/react-aspect-ratio-1.0.49.tgz#346863ebb7eec542b8a5a4d6548440bf95a88608"
-  integrity sha512-zSKVJdy7QjmFeWTNNoL+gLf4KugIVln6XdKNIxjY8yebJ0buCeKcKoEQPfxruSbPGFakFGVl/abtF9SDpauh/A==
+react-aspect-ratio@^1.0.50:
+  version "1.0.50"
+  resolved "https://registry.yarnpkg.com/react-aspect-ratio/-/react-aspect-ratio-1.0.50.tgz#b46bfc6a701d829bd0cb6d001cf271e443874213"
+  integrity sha512-AEAPqmPMLlcuhp4t3z6crb+gGckc0lFPYNL/654a6rrcblcvZGtgh+VpcUbC7AwIE+MT8u5uGeJ7shx0hUOKSw==
 
 react-dev-utils@^10.2.1:
   version "10.2.1"


### PR DESCRIPTION
Thanks for using the package, the package has been updated and the old default export is deprecated (React <= 15.6) 