### PR TITLE
Improves install instructions and hooks usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This package provides React components that makes it easier to use LiveKit in a 
 ## Install
 
 ```bash
-npm install --save livekit-react
+npm install --save livekit-react livekit-client
 ```
 
 ## Demo
@@ -83,11 +83,20 @@ export const MyComponent = () => {
     dynacast: true,
   }
   const { connect, isConnecting, room, error, participants, audioTracks } = useRoom(roomOptions);
-  // initiate connection to the livekit room
-  await connect(livekitUrl, livekitToken);
-  // request camera and microphone permissions and publish tracks
-  room.localParticipant.enableCameraAndMicrophone();
-  ...
+  
+  async function init() {
+    // initiate connection to the livekit room
+    await connect(livekitUrl, livekitToken);
+    // request camera and microphone permissions and publish tracks
+    await room.localParticipant.enableCameraAndMicrophone();
+    ...
+  }
+  
+  useEffect(() => {
+    init().catch(console.error)
+  }, [])
+  
+  return (...)
 }
 
 export const ParticipantRenderer = ({ participant }) => {


### PR DESCRIPTION
This package has a peer dependency on `livekit-client`, it should be explicitly installed (even if newer versions of npm is installing them automatically, it gives warning on yarn for example).

I've also updated the hook usage example for something more realistic, since we can't really await things in the render function of a component (at least not in the current version of React)