### PR TITLE
Add hover style over device option menu entries

### DIFF
--- a/.changeset/early-walls-check.md
+++ b/.changeset/early-walls-check.md
@@ -1,0 +1,5 @@
+---
+'@livekit/react-components': patch
+---
+
+Hover styles for device menu options

--- a/packages/components/src/components/styles.module.css
+++ b/packages/components/src/components/styles.module.css
@@ -163,6 +163,10 @@ ul.list li {
   cursor: pointer;
 }
 
+ul.list li:hover {
+  background: #434343;
+}
+
 ul.list li:first-child {
   border: 0;
 }


### PR DESCRIPTION
Just a small thing that we did in our fork – brings simple visual feedback which input device option is currently hovered over.