### PR TITLE
Don't ignore the example in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,5 @@
   "linked": [],
   "access": "public",
   "baseBranch": "master",
-  "updateInternalDependencies": "patch",
-  "ignore": ["livekit-react-example"]
+  "updateInternalDependencies": "patch"
 }


### PR DESCRIPTION
the repo is not being published anyways due to `private: true` in its package.json. 
This helps with previous CI errors caused by the ignore in the changesets config.