### PR TITLE
Fix disconnect on onmount regression due to strict mode

### DIFF
--- a/.changeset/real-pants-lie.md
+++ b/.changeset/real-pants-lie.md
@@ -1,0 +1,6 @@
+---
+'@livekit/react-components': minor
+'@livekit/react-core': minor
+---
+
+Breaking: useRoom().room could be undefined on first render! Fix auto-disconnect when LiveKitRoom component unmounts"

--- a/packages/components/src/LiveKitRoom.tsx
+++ b/packages/components/src/LiveKitRoom.tsx
@@ -34,21 +34,22 @@ export const LiveKitRoom = ({
   const roomState = useRoom(roomOptions);
 
   useEffect(() => {
-    roomState.connect(url, token, connectOptions).then((room) => {
-      if (!room) {
-        return;
-      }
-      if (onConnected && room.state === ConnectionState.Connected) {
-        onConnected(room);
-      }
-    });
-
+    if (roomState.room) {
+      roomState.connect(url, token, connectOptions).then((room) => {
+        if (!room) {
+          return;
+        }
+        if (onConnected && room.state === ConnectionState.Connected) {
+          onConnected(room);
+        }
+      });
+    }
     return () => {
-      if (roomState.connectionState !== ConnectionState.Disconnected) {
+      if (roomState.room?.state !== ConnectionState.Disconnected) {
         roomState.room?.disconnect();
       }
     };
-  }, []);
+  }, [roomState.room]);
 
   const selectedStageRenderer = stageRenderer ?? StageView;
 


### PR DESCRIPTION
Fixes #111 

React 18's strict mode calls all `useEffect` hooks twice. 
This generally leads to the the useEffect cleanup function being called on a component, even though it never unmounted.

Within `useRoom` in this package, the `room` state was initialized with `useState(new Room())`. 
Because we want the LiveKitRoom component to automatically disconnect when unmounted, this lead to a disconnect call being called on the only existing instance of `room`, when strict-mode's second hook execution invoked the cleanup function. Because this was happening while the room was already connecting it made it effectively impossible to connect to a room in dev mode.
A previous attempt to fix this caused the auto-disconnect logic not to fire at all on component unmount.

This fix re-establishes auto-disconnect behaviour and moves `room` instantiation into a `useEffect` hook in order to prevent `disconnect` being called on the only present room instance. 

This changes the assumption that `useRoom()` always directly returns a valid `Room` object. With this change it can also happen that `room` is `undefined` on the first render, before the useEffect has set its value.
